### PR TITLE
str: Add missing include

### DIFF
--- a/include/stdplus/str/buf.hpp
+++ b/include/stdplus/str/buf.hpp
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <bit>
 #include <cstdint>
 #include <limits>
 #include <memory>


### PR DESCRIPTION
<bit> should be included to use std::endian.